### PR TITLE
feat: implement Obsidian markdown generation for task 8

### DIFF
--- a/.kiro/specs/bookmark-to-obsidian/tasks.md
+++ b/.kiro/specs/bookmark-to-obsidian/tasks.md
@@ -41,7 +41,7 @@
   - タグ情報の抽出機能を実装し、不要な要素（広告、ナビゲーション等）を除去する
   - _要件: 3.3, 3.4_
 
-- [ ] 8. Obsidian形式Markdown生成機能の実装
+- [x] 8. Obsidian形式Markdown生成機能の実装
   - MarkdownGeneratorクラスを実装し、YAML front matterを含むObsidian形式のMarkdownを生成する機能を作成する
   - 記事本文をMarkdown形式に変換し、Obsidianのタグ形式（#タグ名）に対応する機能を実装する
   - 元のブックマーク階層構造を維持したファイルパス生成機能を実装する

--- a/app.py
+++ b/app.py
@@ -1336,6 +1336,523 @@ class WebScraper:
         }
 
 
+class MarkdownGenerator:
+    """
+    Obsidian形式のMarkdown生成クラス
+    記事データからObsidian用のMarkdownファイルを生成する
+    """
+    
+    def __init__(self):
+        """MarkdownGeneratorを初期化"""
+        self.yaml_template = {
+            'title': '',
+            'url': '',
+            'created': '',
+            'tags': [],
+            'description': '',
+            'author': '',
+            'source': 'bookmark-to-obsidian'
+        }
+        
+        logger.info("📝 MarkdownGenerator初期化完了")
+    
+    def generate_obsidian_markdown(self, page_data: Dict, bookmark: 'Bookmark') -> str:
+        """
+        ページデータからObsidian形式のMarkdownを生成
+        
+        Args:
+            page_data: WebScraperから抽出された記事データ
+            bookmark: ブックマーク情報
+            
+        Returns:
+            str: Obsidian形式のMarkdownコンテンツ
+        """
+        try:
+            # YAML front matterを生成
+            yaml_frontmatter = self._create_yaml_frontmatter(page_data, bookmark)
+            
+            # 記事本文をMarkdown形式に変換
+            markdown_content = self._format_content_for_obsidian(page_data.get('content', ''))
+            
+            # タグをObsidian形式に変換
+            obsidian_tags = self._format_tags_for_obsidian(page_data.get('tags', []))
+            
+            # 完全なMarkdownを構築
+            full_markdown = self._build_complete_markdown(
+                yaml_frontmatter, 
+                markdown_content, 
+                obsidian_tags,
+                page_data,
+                bookmark
+            )
+            
+            logger.debug(f"📝 Markdown生成成功: {bookmark.title} (文字数: {len(full_markdown)})")
+            return full_markdown
+            
+        except Exception as e:
+            logger.error(f"❌ Markdown生成エラー: {bookmark.title} - {str(e)}")
+            return self._generate_fallback_markdown(bookmark)
+    
+    def _create_yaml_frontmatter(self, page_data: Dict, bookmark: 'Bookmark') -> str:
+        """
+        YAML front matterを生成
+        
+        Args:
+            page_data: 記事データ
+            bookmark: ブックマーク情報
+            
+        Returns:
+            str: YAML front matter文字列
+        """
+        import datetime
+        
+        # メタデータを準備
+        yaml_data = self.yaml_template.copy()
+        
+        # 基本情報
+        yaml_data['title'] = page_data.get('title', bookmark.title)
+        yaml_data['url'] = bookmark.url
+        yaml_data['created'] = datetime.datetime.now().isoformat()
+        
+        # タグ情報
+        tags = page_data.get('tags', [])
+        if tags:
+            yaml_data['tags'] = tags
+        
+        # メタデータから追加情報を抽出
+        metadata = page_data.get('metadata', {})
+        if metadata.get('description'):
+            yaml_data['description'] = metadata['description']
+        if metadata.get('author'):
+            yaml_data['author'] = metadata['author']
+        
+        # ブックマーク情報
+        if bookmark.add_date:
+            yaml_data['bookmarked'] = bookmark.add_date.isoformat()
+        
+        if bookmark.folder_path:
+            yaml_data['folder'] = '/'.join(bookmark.folder_path)
+        
+        # 品質情報
+        if 'quality_score' in page_data:
+            yaml_data['quality_score'] = page_data['quality_score']
+        if 'extraction_method' in page_data:
+            yaml_data['extraction_method'] = page_data['extraction_method']
+        
+        # シンプルなYAML生成（yamlライブラリを使わない）
+        return self._create_simple_yaml_frontmatter_dict(yaml_data)
+    
+    def _create_simple_yaml_frontmatter_dict(self, yaml_data: Dict) -> str:
+        """
+        辞書からシンプルなYAML front matterを生成
+        
+        Args:
+            yaml_data: YAML用データ辞書
+            
+        Returns:
+            str: YAML front matter文字列
+        """
+        lines = ["---"]
+        
+        for key, value in yaml_data.items():
+            if value:  # 空でない値のみ
+                if isinstance(value, list):
+                    if value:  # 空でないリストのみ
+                        lines.append(f"{key}:")
+                        for item in value:
+                            lines.append(f"  - \"{self._escape_yaml_string(str(item))}\"")
+                elif isinstance(value, (int, float)):
+                    lines.append(f"{key}: {value}")
+                else:
+                    lines.append(f"{key}: \"{self._escape_yaml_string(str(value))}\"")
+        
+        lines.append("---")
+        return '\n'.join(lines) + '\n'
+    
+    def _escape_yaml_string(self, text: str) -> str:
+        """
+        YAML文字列をエスケープ
+        
+        Args:
+            text: エスケープ対象の文字列
+            
+        Returns:
+            str: エスケープされた文字列
+        """
+        if not text:
+            return ""
+        
+        # 危険な文字をエスケープ
+        text = text.replace('"', '\\"')
+        text = text.replace('\n', '\\n')
+        text = text.replace('\r', '\\r')
+        text = text.replace('\t', '\\t')
+        
+        return text
+    
+    def _format_content_for_obsidian(self, content: str) -> str:
+        """
+        記事本文をObsidian用のMarkdown形式に変換
+        
+        Args:
+            content: 元の記事本文
+            
+        Returns:
+            str: Obsidian形式のMarkdown
+        """
+        if not content:
+            return ""
+        
+        # 基本的なMarkdown変換
+        formatted_content = content
+        
+        # 段落の整理
+        paragraphs = [p.strip() for p in formatted_content.split('\n\n') if p.strip()]
+        
+        # Obsidian特有の処理
+        processed_paragraphs = []
+        for paragraph in paragraphs:
+            # 長い段落を適切に分割
+            if len(paragraph) > 500:
+                sentences = self._split_into_sentences(paragraph)
+                processed_paragraphs.extend(sentences)
+            else:
+                processed_paragraphs.append(paragraph)
+        
+        # 最終的なMarkdownを構築
+        markdown_content = '\n\n'.join(processed_paragraphs)
+        
+        # Obsidian特有の記法を適用
+        markdown_content = self._apply_obsidian_formatting(markdown_content)
+        
+        return markdown_content
+    
+    def _split_into_sentences(self, text: str) -> List[str]:
+        """
+        長いテキストを文単位で分割
+        
+        Args:
+            text: 分割対象のテキスト
+            
+        Returns:
+            List[str]: 分割された文のリスト
+        """
+        import re
+        
+        # 日本語と英語の文区切りパターン
+        sentence_patterns = [
+            r'[。！？]',  # 日本語の文末
+            r'[.!?](?:\s|$)',  # 英語の文末
+        ]
+        
+        sentences = []
+        current_sentence = ""
+        
+        for char in text:
+            current_sentence += char
+            
+            # 文末パターンをチェック
+            for pattern in sentence_patterns:
+                if re.search(pattern, current_sentence[-2:]):
+                    if len(current_sentence.strip()) > 10:  # 最小文字数
+                        sentences.append(current_sentence.strip())
+                        current_sentence = ""
+                    break
+        
+        # 残りのテキストを追加
+        if current_sentence.strip():
+            sentences.append(current_sentence.strip())
+        
+        return sentences
+    
+    def _apply_obsidian_formatting(self, content: str) -> str:
+        """
+        Obsidian特有のフォーマットを適用
+        
+        Args:
+            content: 元のコンテンツ
+            
+        Returns:
+            str: Obsidian形式のコンテンツ
+        """
+        # URLを自動リンク化（既存のMarkdownリンクは除外）
+        import re
+        
+        # 既存のMarkdownリンクを保護するため、まず既存のリンクを検出
+        existing_links = re.findall(r'\[([^\]]+)\]\(([^)]+)\)', content)
+        
+        # 既存のリンク以外のHTTPSリンクを検出してObsidian形式に変換
+        # ただし、既にMarkdownリンク内にあるURLは変換しない
+        def replace_url(match):
+            url = match.group()
+            # 既存のリンク内のURLかチェック
+            for link_text, link_url in existing_links:
+                if url in link_url:
+                    return url  # 既存のリンク内なので変換しない
+            return f"[{url}]({url})"
+        
+        # 単独のURLのみを変換（Markdownリンク内でないもの）
+        url_pattern = r'(?<!\]\()https?://[^\s<>"\']+[^\s<>"\'.,;:!?](?!\))'
+        content = re.sub(url_pattern, replace_url, content)
+        
+        return content
+    
+    def _format_tags_for_obsidian(self, tags: List[str]) -> str:
+        """
+        タグをObsidian形式（#タグ名）に変換
+        
+        Args:
+            tags: タグのリスト
+            
+        Returns:
+            str: Obsidian形式のタグ文字列
+        """
+        if not tags:
+            return ""
+        
+        obsidian_tags = []
+        
+        for tag in tags:
+            # タグのクリーニング
+            clean_tag = self._clean_tag_for_obsidian(tag)
+            if clean_tag:
+                obsidian_tags.append(f"#{clean_tag}")
+        
+        if obsidian_tags:
+            return "\n\n## タグ\n\n" + " ".join(obsidian_tags)
+        
+        return ""
+    
+    def _clean_tag_for_obsidian(self, tag: str) -> str:
+        """
+        タグをObsidian用にクリーニング
+        
+        Args:
+            tag: 元のタグ
+            
+        Returns:
+            str: クリーニングされたタグ
+        """
+        import re
+        
+        if not tag:
+            return ""
+        
+        clean_tag = tag.strip()
+        
+        # スペースをハイフンに変換
+        clean_tag = re.sub(r'\s+', '-', clean_tag)
+        
+        # 特殊文字をハイフンに変換（スラッシュ、ドットなど）
+        clean_tag = re.sub(r'[/\\.+]', '-', clean_tag)
+        
+        # 許可されない文字を除去（英数字、日本語、ハイフン、アンダースコアのみ）
+        clean_tag = re.sub(r'[^\w\-ぁ-んァ-ヶ一-龯]', '', clean_tag)
+        
+        # 先頭と末尾のハイフンを除去
+        clean_tag = clean_tag.strip('-_')
+        
+        # 長すぎる場合は切り詰め
+        if len(clean_tag) > 50:
+            clean_tag = clean_tag[:50]
+        
+        return clean_tag
+    
+    def _build_complete_markdown(self, yaml_frontmatter: str, content: str, tags: str, page_data: Dict, bookmark: 'Bookmark') -> str:
+        """
+        完全なMarkdownドキュメントを構築
+        
+        Args:
+            yaml_frontmatter: YAML front matter
+            content: 記事本文
+            tags: Obsidianタグ
+            page_data: 記事データ
+            bookmark: ブックマーク情報
+            
+        Returns:
+            str: 完全なMarkdownドキュメント
+        """
+        sections = [yaml_frontmatter]
+        
+        # タイトル
+        title = page_data.get('title', bookmark.title)
+        sections.append(f"# {title}\n")
+        
+        # 元URL情報
+        sections.append(f"**元URL:** [{bookmark.url}]({bookmark.url})\n")
+        
+        # ブックマーク日時
+        if bookmark.add_date:
+            sections.append(f"**ブックマーク日時:** {bookmark.add_date.strftime('%Y-%m-%d %H:%M:%S')}\n")
+        
+        # フォルダ情報
+        if bookmark.folder_path:
+            folder_path = ' > '.join(bookmark.folder_path)
+            sections.append(f"**フォルダ:** {folder_path}\n")
+        
+        # 記事本文
+        if content:
+            sections.append("## 記事内容\n")
+            sections.append(content)
+        
+        # タグセクション
+        if tags:
+            sections.append(tags)
+        
+        # メタデータセクション
+        metadata = page_data.get('metadata', {})
+        if metadata:
+            sections.append("\n## メタデータ\n")
+            
+            if metadata.get('description'):
+                sections.append(f"**説明:** {metadata['description']}\n")
+            
+            if metadata.get('author'):
+                sections.append(f"**著者:** {metadata['author']}\n")
+            
+            # 品質情報
+            if 'quality_score' in page_data:
+                sections.append(f"**品質スコア:** {page_data['quality_score']:.2f}\n")
+            
+            if 'extraction_method' in page_data:
+                sections.append(f"**抽出方法:** {page_data['extraction_method']}\n")
+        
+        # セクションを結合
+        return '\n'.join(sections)
+    
+    def _generate_fallback_markdown(self, bookmark: 'Bookmark') -> str:
+        """
+        フォールバック用のシンプルなMarkdownを生成
+        
+        Args:
+            bookmark: ブックマーク情報
+            
+        Returns:
+            str: フォールバック用Markdown
+        """
+        import datetime
+        
+        lines = [
+            "---",
+            f"title: \"{self._escape_yaml_string(bookmark.title)}\"",
+            f"url: \"{bookmark.url}\"",
+            f"created: \"{datetime.datetime.now().isoformat()}\"",
+            "source: \"bookmark-to-obsidian\"",
+            "status: \"extraction_failed\"",
+            "---",
+            "",
+            f"# {bookmark.title}",
+            "",
+            f"**元URL:** [{bookmark.url}]({bookmark.url})",
+            "",
+            "## 注意",
+            "",
+            "このページの内容を自動抽出できませんでした。",
+            "元のURLにアクセスして内容を確認してください。",
+            ""
+        ]
+        
+        if bookmark.add_date:
+            lines.insert(-3, f"**ブックマーク日時:** {bookmark.add_date.strftime('%Y-%m-%d %H:%M:%S')}")
+        
+        if bookmark.folder_path:
+            folder_path = ' > '.join(bookmark.folder_path)
+            lines.insert(-3, f"**フォルダ:** {folder_path}")
+        
+        return '\n'.join(lines)
+    
+    def generate_file_path(self, bookmark: 'Bookmark', base_path: Path) -> Path:
+        """
+        ブックマーク階層構造を維持したファイルパスを生成
+        
+        Args:
+            bookmark: ブックマーク情報
+            base_path: 基準パス
+            
+        Returns:
+            Path: 生成されたファイルパス
+        """
+        try:
+            # フォルダ階層を構築
+            folder_parts = []
+            if bookmark.folder_path:
+                for folder in bookmark.folder_path:
+                    # フォルダ名をファイルシステム用にサニタイズ
+                    clean_folder = self._sanitize_path_component(folder)
+                    if clean_folder:
+                        folder_parts.append(clean_folder)
+            
+            # ファイル名を生成
+            filename = self._sanitize_path_component(bookmark.title)
+            if not filename:
+                filename = "untitled"
+            
+            # 拡張子を追加
+            filename += ".md"
+            
+            # 完全なパスを構築
+            if folder_parts:
+                full_path = base_path / Path(*folder_parts) / filename
+            else:
+                full_path = base_path / filename
+            
+            logger.debug(f"📁 ファイルパス生成: {full_path}")
+            return full_path
+            
+        except Exception as e:
+            logger.error(f"❌ ファイルパス生成エラー: {bookmark.title} - {str(e)}")
+            # フォールバック: ルートディレクトリに保存
+            safe_filename = f"bookmark_{hash(bookmark.url) % 10000}.md"
+            return base_path / safe_filename
+    
+    def _sanitize_path_component(self, name: str) -> str:
+        """
+        パス要素をファイルシステム用にサニタイズ
+        
+        Args:
+            name: 元の名前
+            
+        Returns:
+            str: サニタイズされた名前
+        """
+        import re
+        
+        if not name:
+            return ""
+        
+        # 危険な文字を除去・置換
+        sanitized = re.sub(r'[<>:"/\\|?*]', '_', name)
+        
+        # 連続するアンダースコアを単一に
+        sanitized = re.sub(r'_+', '_', sanitized)
+        
+        # 前後の空白とアンダースコアを除去
+        sanitized = sanitized.strip(' _.')
+        
+        # 長すぎる場合は切り詰め
+        if len(sanitized) > 100:
+            sanitized = sanitized[:100]
+        
+        # 予約語をチェック（Windows）
+        reserved_names = ['CON', 'PRN', 'AUX', 'NUL', 'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9', 'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9']
+        if sanitized.upper() in reserved_names:
+            sanitized = f"_{sanitized}"
+        
+        return sanitized
+    
+    def get_statistics(self) -> Dict[str, Any]:
+        """
+        MarkdownGenerator統計情報を取得
+        
+        Returns:
+            Dict[str, Any]: 統計情報
+        """
+        return {
+            'yaml_template_keys': len(self.yaml_template),
+            'supported_formats': ['obsidian', 'yaml', 'markdown']
+        }
+
+
 def validate_bookmarks_file(uploaded_file) -> tuple[bool, str]:
     """
     アップロードされたファイルがbookmarks.htmlとして有効かを検証する

--- a/tests/test_markdown_generator.py
+++ b/tests/test_markdown_generator.py
@@ -1,0 +1,293 @@
+"""
+Obsidian形式Markdown生成機能のテスト
+Task 8の実装確認用
+"""
+
+import pytest
+import sys
+import os
+from pathlib import Path
+from datetime import datetime
+
+# プロジェクトルートをパスに追加
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from app import MarkdownGenerator, Bookmark
+
+
+class TestMarkdownGenerator:
+    """Obsidian形式Markdown生成機能のテストクラス"""
+    
+    @pytest.fixture
+    def generator(self):
+        """MarkdownGeneratorインスタンスを提供するフィクスチャ"""
+        return MarkdownGenerator()
+    
+    @pytest.fixture
+    def sample_bookmark(self):
+        """サンプルブックマークを提供するフィクスチャ"""
+        return Bookmark(
+            title="テスト記事のタイトル",
+            url="https://example.com/test-article",
+            folder_path=["技術", "Python"],
+            add_date=datetime(2024, 1, 1, 12, 0, 0)
+        )
+    
+    @pytest.fixture
+    def sample_page_data(self):
+        """サンプルページデータを提供するフィクスチャ"""
+        return {
+            'title': 'テスト記事のタイトル',
+            'content': 'これはテスト記事の本文です。\n\n複数の段落があります。\n\n最後の段落です。',
+            'tags': ['Python', 'テスト', 'プログラミング'],
+            'metadata': {
+                'description': 'テスト記事の説明',
+                'author': 'テスト作者',
+                'keywords': 'Python,テスト'
+            },
+            'quality_score': 0.85,
+            'extraction_method': 'semantic_tags'
+        }
+    
+    def test_markdown_generator_initialization(self, generator):
+        """MarkdownGenerator初期化テスト"""
+        assert hasattr(generator, 'yaml_template')
+        assert hasattr(generator, 'generate_obsidian_markdown')
+        assert hasattr(generator, 'generate_file_path')
+        assert generator.yaml_template['source'] == 'bookmark-to-obsidian'
+    
+    def test_yaml_frontmatter_creation(self, generator, sample_page_data, sample_bookmark):
+        """YAML front matter生成テスト"""
+        yaml_frontmatter = generator._create_yaml_frontmatter(sample_page_data, sample_bookmark)
+        
+        # YAML構造の確認
+        assert yaml_frontmatter.startswith('---\n')
+        assert yaml_frontmatter.endswith('---\n')
+        
+        # 必要な情報が含まれていることを確認
+        assert 'title: "テスト記事のタイトル"' in yaml_frontmatter
+        assert 'url: "https://example.com/test-article"' in yaml_frontmatter
+        assert 'source: "bookmark-to-obsidian"' in yaml_frontmatter
+        assert 'description: "テスト記事の説明"' in yaml_frontmatter
+        assert 'author: "テスト作者"' in yaml_frontmatter
+        assert 'quality_score: 0.85' in yaml_frontmatter
+        
+        # タグが正しく含まれていることを確認
+        assert 'tags:' in yaml_frontmatter
+        assert '- "Python"' in yaml_frontmatter
+        assert '- "テスト"' in yaml_frontmatter
+    
+    def test_yaml_string_escaping(self, generator):
+        """YAML文字列エスケープテスト"""
+        # 特殊文字を含む文字列
+        test_string = 'テスト"引用符\n改行\tタブ'
+        escaped = generator._escape_yaml_string(test_string)
+        
+        assert '\\"' in escaped  # 引用符がエスケープされている
+        assert '\\n' in escaped  # 改行がエスケープされている
+        assert '\\t' in escaped  # タブがエスケープされている
+    
+    def test_content_formatting_for_obsidian(self, generator):
+        """Obsidian用コンテンツフォーマットテスト"""
+        test_content = "これはテスト記事です。\n\nhttps://example.com のリンクがあります。\n\n最後の段落です。"
+        
+        formatted = generator._format_content_for_obsidian(test_content)
+        
+        # URLが自動リンク化されていることを確認
+        assert '[https://example.com](https://example.com)' in formatted
+        
+        # 段落構造が保持されていることを確認
+        assert 'これはテスト記事です。' in formatted
+        assert '最後の段落です。' in formatted
+    
+    def test_tags_formatting_for_obsidian(self, generator):
+        """Obsidianタグフォーマットテスト"""
+        test_tags = ['Python', 'Web Scraping', 'テスト記事', 'AI/ML']
+        
+        formatted_tags = generator._format_tags_for_obsidian(test_tags)
+        
+        # タグセクションが生成されていることを確認
+        assert '## タグ' in formatted_tags
+        
+        # Obsidian形式のタグが生成されていることを確認
+        assert '#Python' in formatted_tags
+        assert '#Web-Scraping' in formatted_tags  # スペースがハイフンに変換
+        assert '#テスト記事' in formatted_tags
+        assert '#AI-ML' in formatted_tags  # スラッシュがハイフンに変換
+    
+    def test_tag_cleaning_for_obsidian(self, generator):
+        """Obsidianタグクリーニングテスト"""
+        # 様々な特殊文字を含むタグ
+        test_cases = [
+            ('Python 3.9', 'Python-3-9'),
+            ('Web/API', 'Web-API'),
+            ('C++', 'C'),
+            ('データ分析', 'データ分析'),
+            ('  spaced  ', 'spaced'),
+            ('', ''),
+            ('very-long-tag-name-that-exceeds-fifty-characters-limit', 'very-long-tag-name-that-exceeds-fifty-characters-l')
+        ]
+        
+        for input_tag, expected in test_cases:
+            result = generator._clean_tag_for_obsidian(input_tag)
+            assert result == expected, f"Input: '{input_tag}' -> Expected: '{expected}', Got: '{result}'"
+    
+    def test_sentence_splitting(self, generator):
+        """文分割機能テスト"""
+        long_text = "これは長い文章です。複数の文が含まれています！最後の文もあります？"
+        
+        sentences = generator._split_into_sentences(long_text)
+        
+        # 適切に分割されていることを確認
+        assert len(sentences) >= 2
+        assert any('長い文章です。' in s for s in sentences)
+        assert any('含まれています！' in s for s in sentences)
+        assert any('あります？' in s for s in sentences)
+    
+    def test_complete_markdown_generation(self, generator, sample_page_data, sample_bookmark):
+        """完全なMarkdown生成テスト"""
+        markdown = generator.generate_obsidian_markdown(sample_page_data, sample_bookmark)
+        
+        # YAML front matterが含まれていることを確認
+        assert markdown.startswith('---\n')
+        
+        # タイトルが含まれていることを確認
+        assert '# テスト記事のタイトル' in markdown
+        
+        # 元URL情報が含まれていることを確認
+        assert '**元URL:**' in markdown
+        assert 'https://example.com/test-article' in markdown
+        
+        # ブックマーク日時が含まれていることを確認
+        assert '**ブックマーク日時:**' in markdown
+        assert '2024-01-01' in markdown
+        
+        # フォルダ情報が含まれていることを確認
+        assert '**フォルダ:**' in markdown
+        assert '技術 > Python' in markdown
+        
+        # 記事内容が含まれていることを確認
+        assert '## 記事内容' in markdown
+        assert 'これはテスト記事の本文です。' in markdown
+        
+        # タグが含まれていることを確認
+        assert '## タグ' in markdown
+        assert '#Python' in markdown
+        
+        # メタデータが含まれていることを確認
+        assert '## メタデータ' in markdown
+        assert '**説明:**' in markdown
+        assert '**著者:**' in markdown
+        assert '**品質スコア:**' in markdown
+    
+    def test_fallback_markdown_generation(self, generator, sample_bookmark):
+        """フォールバックMarkdown生成テスト"""
+        fallback_markdown = generator._generate_fallback_markdown(sample_bookmark)
+        
+        # 基本構造が含まれていることを確認
+        assert fallback_markdown.startswith('---\n')
+        assert '# テスト記事のタイトル' in fallback_markdown
+        assert '**元URL:**' in fallback_markdown
+        assert 'status: "extraction_failed"' in fallback_markdown
+        
+        # 注意メッセージが含まれていることを確認
+        assert '## 注意' in fallback_markdown
+        assert '自動抽出できませんでした' in fallback_markdown
+    
+    def test_file_path_generation(self, generator, sample_bookmark):
+        """ファイルパス生成テスト"""
+        base_path = Path("/test/base")
+        
+        file_path = generator.generate_file_path(sample_bookmark, base_path)
+        
+        # 正しいパス構造が生成されていることを確認
+        expected_path = base_path / "技術" / "Python" / "テスト記事のタイトル.md"
+        assert file_path == expected_path
+    
+    def test_file_path_generation_no_folder(self, generator):
+        """フォルダなしブックマークのファイルパス生成テスト"""
+        bookmark = Bookmark(
+            title="ルート記事",
+            url="https://example.com/root",
+            folder_path=[]
+        )
+        base_path = Path("/test/base")
+        
+        file_path = generator.generate_file_path(bookmark, base_path)
+        
+        # ルートディレクトリに配置されることを確認
+        expected_path = base_path / "ルート記事.md"
+        assert file_path == expected_path
+    
+    def test_path_component_sanitization(self, generator):
+        """パス要素サニタイズテスト"""
+        test_cases = [
+            ('正常なファイル名', '正常なファイル名'),
+            ('危険な<>:"/\\|?*文字', '危険な_文字'),
+            ('  前後スペース  ', '前後スペース'),
+            ('連続___アンダースコア', '連続_アンダースコア'),
+            ('', ''),
+            ('CON', '_CON'),  # Windows予約語
+        ]
+        
+        for input_name, expected in test_cases:
+            result = generator._sanitize_path_component(input_name)
+            assert result == expected, f"Input: '{input_name}' -> Expected: '{expected}', Got: '{result}'"
+        
+        # 長いファイル名のテスト（別途）
+        long_name = 'very-long-filename-that-exceeds-one-hundred-characters-and-should-be-truncated-automatically'
+        result = generator._sanitize_path_component(long_name)
+        assert len(result) <= 100, f"Result length {len(result)} should be <= 100"
+        assert result.startswith('very-long-filename'), "Should start with expected prefix"
+    
+    def test_statistics(self, generator):
+        """統計情報取得テスト"""
+        stats = generator.get_statistics()
+        
+        # 統計情報の構造確認
+        assert 'yaml_template_keys' in stats
+        assert 'supported_formats' in stats
+        
+        # 値の確認
+        assert stats['yaml_template_keys'] > 0
+        assert 'obsidian' in stats['supported_formats']
+        assert 'yaml' in stats['supported_formats']
+        assert 'markdown' in stats['supported_formats']
+    
+    def test_empty_content_handling(self, generator, sample_bookmark):
+        """空コンテンツの処理テスト"""
+        empty_page_data = {
+            'title': 'タイトルのみ',
+            'content': '',
+            'tags': [],
+            'metadata': {}
+        }
+        
+        markdown = generator.generate_obsidian_markdown(empty_page_data, sample_bookmark)
+        
+        # 基本構造は生成されることを確認
+        assert '# タイトルのみ' in markdown
+        assert '**元URL:**' in markdown
+        
+        # 空のセクションは含まれないことを確認
+        assert '## 記事内容' not in markdown or markdown.count('## 記事内容') == 0
+        assert '## タグ' not in markdown
+    
+    def test_special_characters_in_content(self, generator, sample_bookmark):
+        """コンテンツ内特殊文字の処理テスト"""
+        special_page_data = {
+            'title': 'Special Characters Test',
+            'content': 'Content with **bold**, *italic*, `code`, and [links](https://example.com)',
+            'tags': ['markdown', 'formatting'],
+            'metadata': {}
+        }
+        
+        markdown = generator.generate_obsidian_markdown(special_page_data, sample_bookmark)
+        
+        # Markdown記法が保持されていることを確認
+        assert '**bold**' in markdown
+        assert '*italic*' in markdown
+        assert '`code`' in markdown
+        # 既存のリンクが保持されていることを確認（自動リンク化で壊されていない）
+        assert 'links](https://example.com)' in markdown


### PR DESCRIPTION
- Add MarkdownGenerator class with comprehensive Obsidian support
- Implement YAML front matter generation with metadata extraction
- Add content formatting for Obsidian with URL auto-linking
- Implement Obsidian tag formatting (#tag-name) with cleaning
- Add file path generation maintaining bookmark folder structure
- Include path component sanitization for filesystem safety
- Add fallback markdown generation for extraction failures
- Implement sentence splitting for long content optimization
- Add comprehensive test suite with pytest (15 tests, all passing)
- Support special characters, reserved names, and long filenames
- Update task 8 status to completed

Addresses requirements 4.1, 4.2, and 4.3 from the specification